### PR TITLE
fix(cv): resolve stale cache issues for public site and API

### DIFF
--- a/src/actions/cv.action.ts
+++ b/src/actions/cv.action.ts
@@ -46,6 +46,8 @@ export async function uploadCvAction(payload: Record<string, unknown>): Promise<
     });
 
     revalidatePath('/admin/cv');
+    revalidatePath('/');
+    revalidatePath('/api/cv');
     return { success: true, data: { url, name: 'CV_OKBA_Hedi.pdf' } };
   } catch (error) {
     console.error('[actions/cv:upload]', error);
@@ -66,6 +68,8 @@ export async function deleteCvAction(): Promise<ActionResult> {
     await prisma.cv.deleteMany();
 
     revalidatePath('/admin/cv');
+    revalidatePath('/');
+    revalidatePath('/api/cv');
     return { success: true };
   } catch (error) {
     console.error('[actions/cv:delete]', error);

--- a/src/app/api/admin/cloudinary/sign/route.ts
+++ b/src/app/api/admin/cloudinary/sign/route.ts
@@ -40,9 +40,10 @@ export async function POST(req: Request) {
     const timestamp = Math.round(Date.now() / 1000);
 
     // Parameters to sign (must match exactly those sent to Cloudinary)
-    const paramsToSign: Record<string, string | number> = {
+    const paramsToSign: Record<string, string | number | boolean> = {
       timestamp,
       folder,
+      invalidate: true,
     };
 
     if (public_id) {

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -1,6 +1,9 @@
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
+// Always hit DB — CV can be deleted at any time from admin
+export const dynamic = 'force-dynamic';
+
 /**
  * Proxies Cloudinary PDF to same-origin to bypass CORS and CSP restrictions.
  */
@@ -31,7 +34,7 @@ export async function GET(request: NextRequest) {
         'Content-Disposition': isDownload
           ? 'attachment; filename="CV_OKBA_Hedi.pdf"'
           : 'inline; filename="CV_OKBA_Hedi.pdf"',
-        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
         'Content-Length': String(pdfBuffer.byteLength),
         // Override global DENY for same-origin iframes
         'X-Frame-Options': 'SAMEORIGIN',

--- a/src/app/sections/Contact.tsx
+++ b/src/app/sections/Contact.tsx
@@ -272,7 +272,7 @@ export default function Contact() {
                       {/* Multi-file upload UI */}
                       <div>
                         <label className="block text-sm font-medium text-neutral-600 dark:text-neutral-300 mb-1.5">
-                          Pièces jointes (optionnel - max 10 Mo)
+                          Pièces jointes (optionnel - max 10 Mo par pièce)
                         </label>
                         <div className="relative group">
                           <input

--- a/src/lib/cloudinary-client.ts
+++ b/src/lib/cloudinary-client.ts
@@ -51,6 +51,7 @@ export async function directUploadToCloudinary(
   formData.append('signature', signature);
   formData.append('api_key', apiKey);
   formData.append('folder', folder);
+  formData.append('invalidate', 'true');
 
   if (options.public_id) {
     formData.append('public_id', options.public_id);


### PR DESCRIPTION
### 🚀 Correctif : Synchronisation et Cache du CV

Cette PR corrige le problème de persistance de l'ancien CV après une suppression ou une mise à jour dans l'espace administration. Le problème était causé par plusieurs couches de cache (Next.js ISR, Cache Navigateur et CDN Cloudinary).

#### 🛠️ Changements apportés :

1. **Revalidation des Chemins :**
   - Les actions `uploadCvAction` et `deleteCvAction` déclenchent maintenant une revalidation immédiate de la page d'accueil (`/`) et de la route API (`/api/cv`).

2. **Optimisation de l'API CV :**
   - Passage de la route `/api/cv` en **mode dynamique forcé** (`force-dynamic`) pour garantir une vérification en base de données à chaque appel.
   - Désactivation du cache HTTP (`Cache-Control: no-cache, no-store, must-revalidate`) pour éviter que le navigateur ou les proxys ne conservent l'ancien fichier PDF.

3. **Invalidation Cloudinary :**
   - Ajout de l'option `invalidate: true` lors de l'upload direct depuis le client. Cela force Cloudinary à vider son propre cache CDN, indispensable puisque le fichier est remplacé sous le même `public_id`.

#### ✅ Résultat :
Toute modification (ajout, remplacement ou suppression) du CV depuis l'admin est désormais répercutée instantanément sur le site public pour les visiteurs.