### PR TITLE
Resolve stale cache issues for public site and CV API

### DIFF
--- a/src/actions/cv.action.ts
+++ b/src/actions/cv.action.ts
@@ -46,6 +46,8 @@ export async function uploadCvAction(payload: Record<string, unknown>): Promise<
     });
 
     revalidatePath('/admin/cv');
+    revalidatePath('/');
+    revalidatePath('/api/cv');
     return { success: true, data: { url, name: 'CV_OKBA_Hedi.pdf' } };
   } catch (error) {
     console.error('[actions/cv:upload]', error);
@@ -66,6 +68,8 @@ export async function deleteCvAction(): Promise<ActionResult> {
     await prisma.cv.deleteMany();
 
     revalidatePath('/admin/cv');
+    revalidatePath('/');
+    revalidatePath('/api/cv');
     return { success: true };
   } catch (error) {
     console.error('[actions/cv:delete]', error);

--- a/src/app/api/admin/cloudinary/sign/route.ts
+++ b/src/app/api/admin/cloudinary/sign/route.ts
@@ -40,9 +40,10 @@ export async function POST(req: Request) {
     const timestamp = Math.round(Date.now() / 1000);
 
     // Parameters to sign (must match exactly those sent to Cloudinary)
-    const paramsToSign: Record<string, string | number> = {
+    const paramsToSign: Record<string, string | number | boolean> = {
       timestamp,
       folder,
+      invalidate: true,
     };
 
     if (public_id) {

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -1,6 +1,9 @@
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 
+// Always hit DB — CV can be deleted at any time from admin
+export const dynamic = 'force-dynamic';
+
 /**
  * Proxies Cloudinary PDF to same-origin to bypass CORS and CSP restrictions.
  */
@@ -31,7 +34,7 @@ export async function GET(request: NextRequest) {
         'Content-Disposition': isDownload
           ? 'attachment; filename="CV_OKBA_Hedi.pdf"'
           : 'inline; filename="CV_OKBA_Hedi.pdf"',
-        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
         'Content-Length': String(pdfBuffer.byteLength),
         // Override global DENY for same-origin iframes
         'X-Frame-Options': 'SAMEORIGIN',

--- a/src/app/sections/Contact.tsx
+++ b/src/app/sections/Contact.tsx
@@ -272,7 +272,7 @@ export default function Contact() {
                       {/* Multi-file upload UI */}
                       <div>
                         <label className="block text-sm font-medium text-neutral-600 dark:text-neutral-300 mb-1.5">
-                          Pièces jointes (optionnel - max 10 Mo)
+                          Pièces jointes (optionnel - max 10 Mo par pièce)
                         </label>
                         <div className="relative group">
                           <input

--- a/src/lib/cloudinary-client.ts
+++ b/src/lib/cloudinary-client.ts
@@ -51,6 +51,7 @@ export async function directUploadToCloudinary(
   formData.append('signature', signature);
   formData.append('api_key', apiKey);
   formData.append('folder', folder);
+  formData.append('invalidate', 'true');
 
   if (options.public_id) {
     formData.append('public_id', options.public_id);


### PR DESCRIPTION
## 🏁 Finalisation de la gestion dynamique du CV

Cette PR fusionne les correctifs critiques liés à la gestion du CV, garantissant une synchronisation parfaite entre l'espace admin et le site public.

### 📝 Résumé des corrections :
- **Fiabilité des données :** Suppression définitive des problèmes de cache (ISR & Browser) qui affichaient un CV obsolète ou supprimé.
- **API Robuste :** La route de proxy du CV est désormais 100% dynamique et ne stocke plus de copie locale périmée.
- **Synchronisation Cloudinary :** Invalidation forcée du CDN Cloudinary pour garantir que le nouveau fichier PDF est servi immédiatement après un remplacement.

### 🛠️ Détails techniques :
- Ajout de `revalidatePath` sur les routes stratégiques (`/`, `/api/cv`).
- Entêtes `Cache-Control` mis à jour pour interdire le stockage persistant du PDF.
- Configuration `force-dynamic` sur l'endpoint de récupération.
- Signature Cloudinary mise à jour pour inclure l'invalidation CDN.

**Tests :** 
- Build Next.js validé (Success).
- Flux de suppression et de remplacement vérifiés.
