### PR TITLE
fix: restore cross-page navigation for mobile navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -383,10 +383,13 @@ export default function Navbar() {
                       <Link
                         href={link.href}
                         onClick={(e) => {
-                          e.preventDefault();
-                          // On scrolle d'abord, puis on ferme le menu pour éviter les saccades
-                          smoothScrollTo(link.section, 2000);
-                          setTimeout(handleLinkClick, 100);
+                          if (pathname === '/') {
+                            e.preventDefault();
+                            smoothScrollTo(link.section, 2000);
+                            setTimeout(handleLinkClick, 100);
+                          } else {
+                            handleLinkClick();
+                          }
                         }}
                         className={`flex items-center gap-4 px-4 py-3 rounded-xl transition-all duration-200 ${
                           isActive


### PR DESCRIPTION
### 🐛 Correction de la navigation mobile inter-pages

Cette PR corrige un bug bloquant sur mobile où la navigation depuis les pages Admin/Login vers la page d'accueil ne fonctionnait pas.

#### Problème :
Le `e.preventDefault()` forçait le scroll fluide même sur les pages d'administration, bloquant ainsi la redirection vers le site public car les sections cibles n'existaient pas sur les pages admin.

#### Solution :
- Ajout d'une condition vérifiant que l'utilisateur est sur la page d'accueil (`/`) avant d'intercepter le clic.
- Permet une navigation fluide et correcte depuis n'importe quelle page (Admin, Login, etc.) vers les sections du site public.
