### PR TITLE
Restore cross-page navigation for mobile navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -383,10 +383,13 @@ export default function Navbar() {
                       <Link
                         href={link.href}
                         onClick={(e) => {
-                          e.preventDefault();
-                          // On scrolle d'abord, puis on ferme le menu pour éviter les saccades
-                          smoothScrollTo(link.section, 2000);
-                          setTimeout(handleLinkClick, 100);
+                          if (pathname === '/') {
+                            e.preventDefault();
+                            smoothScrollTo(link.section, 2000);
+                            setTimeout(handleLinkClick, 100);
+                          } else {
+                            handleLinkClick();
+                          }
                         }}
                         className={`flex items-center gap-4 px-4 py-3 rounded-xl transition-all duration-200 ${
                           isActive


### PR DESCRIPTION
### 🐛 Fix: Navigation Mobile Inter-Pages

Ce correctif résout un problème bloquant où il était impossible de revenir sur le site public depuis les pages d'administration (Admin, Login) sur mobile.

- **Correction** : Désactivation du `preventDefault` et du scroll fluide quand l'utilisateur n'est pas sur la page d'accueil.
- **Résultat** : La navigation mobile est désormais fluide et fonctionnelle entre toutes les pages du site.
