### PR TITLE
Fix email sending failure by introducing EMAIL_FROM variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,11 +27,14 @@ NEXT_TELEMETRY_DISABLED="1"
 # ─── Security ────────────────────────────────────────────
 OTP_ENCRYPTION_KEY="your-otp-encryption-key"
 
-# ─── Email transport ────────────────────────────────────
-# Resend SDK (production/staging)
+# ─── Email transport ────────────────────────────────────────
+# Sender address (required in ALL environments)
+EMAIL_FROM="Portfolio <contact@your-verified-domain.com>"
+
+# Resend SDK (production/staging — set this to enable Resend)
 RESEND_API_KEY="re_your-resend-api-key"
 
-# SMTP (local dev via Mailpit)
+# SMTP (local dev via Mailpit — used when RESEND_API_KEY is absent)
 SMTP_FROM="Portfolio <contact@example.com>"
 SMTP_HOST="mailpit"
 SMTP_PASS="none"

--- a/src/actions/contact.action.ts
+++ b/src/actions/contact.action.ts
@@ -133,7 +133,6 @@ export async function submitContact(
     const userHtml = await render(UserConfirmation({ name }));
 
     await sendEmail({
-      from: process.env.SMTP_FROM as string,
       to: destinataire,
       replyTo: email,
       subject: emailSubject,
@@ -142,7 +141,6 @@ export async function submitContact(
     });
 
     await sendEmail({
-      from: process.env.SMTP_FROM as string,
       to: email,
       subject: `${prefixe}Merci pour ton message !`,
       html: userHtml,

--- a/src/actions/message.action.ts
+++ b/src/actions/message.action.ts
@@ -230,7 +230,6 @@ export async function sendReplyAction(
     });
 
     await sendEmail({
-      from: process.env.SMTP_FROM as string,
       to: contact.email,
       subject: `${prefixe}Réponse à votre message — Hëdi OKBA`,
       html,

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -62,7 +62,6 @@ export async function POST(req: Request) {
     const html = await render(PasswordReset({ resetLink }));
 
     await sendEmail({
-      from: process.env.SMTP_FROM as string,
       to: admin.email,
       subject: `${prefixe}Password Reset Request`,
       html,

--- a/src/app/sections/Contact.tsx
+++ b/src/app/sections/Contact.tsx
@@ -165,7 +165,7 @@ export default function Contact() {
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.15 }}
-                className="fixed inset-0 bg-black/60 backdrop-blur-md flex justify-center items-center z-[9999] p-4"
+                className="fixed inset-0 bg-black/60 backdrop-blur-md flex justify-center items-center z-9999 p-4"
                 onClick={handleClose}
               >
                 <m.div
@@ -173,7 +173,7 @@ export default function Contact() {
                   animate={{ scale: 1, opacity: 1, y: 0 }}
                   exit={{ scale: 0.95, opacity: 0, y: 10 }}
                   transition={{ duration: 0.15, ease: 'easeOut' }}
-                  className="bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 shadow-2xl rounded-2xl max-w-lg w-full p-8 relative text-left"
+                  className="bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 shadow-2xl rounded-2xl max-w-lg w-full p-6 md:p-8 relative text-left max-h-dvh md:max-h-[90vh] overflow-y-auto"
                   onClick={(e) => e.stopPropagation()}
                 >
                   <button

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -1,9 +1,11 @@
 import nodemailer from 'nodemailer';
+import type { Transporter } from 'nodemailer';
 import { Resend } from 'resend';
 
 // ─── Shared Email Interface ────────────────────────────────────────
 export interface SendEmailOptions {
-  from: string;
+  /** Sender address. Falls back to EMAIL_FROM or SMTP_FROM env var if omitted. */
+  from?: string;
   to: string;
   subject: string;
   html: string;
@@ -15,19 +17,38 @@ export interface SendEmailOptions {
 const isResendConfigured = !!process.env.RESEND_API_KEY;
 
 /**
+ * Resolves the sender address from env vars.
+ * Checks EMAIL_FROM first, then SMTP_FROM for backward compatibility.
+ */
+function getDefaultFromAddress(): string {
+  const from = process.env.EMAIL_FROM || process.env.SMTP_FROM;
+  if (!from) {
+    throw new Error(
+      '[Mailer] Missing sender address: set EMAIL_FROM or SMTP_FROM in environment variables.',
+    );
+  }
+  return from;
+}
+
+/**
  * Sends an email using Resend SDK (Prod/Staging) or SMTP/Mailpit (Local).
  * Automatically toggles transport based on RESEND_API_KEY presence.
  */
 export async function sendEmail(options: SendEmailOptions): Promise<void> {
+  const resolvedOptions = {
+    ...options,
+    from: options.from || getDefaultFromAddress(),
+  };
+
   if (isResendConfigured) {
-    await sendViaResend(options);
+    await sendViaResend(resolvedOptions);
   } else {
-    await sendViaSMTP(options);
+    await sendViaSMTP(resolvedOptions);
   }
 }
 
 // ─── Resend SDK Transport (Production / Staging) ───────────────────
-async function sendViaResend(options: SendEmailOptions): Promise<void> {
+async function sendViaResend(options: SendEmailOptions & { from: string }): Promise<void> {
   const resend = new Resend(process.env.RESEND_API_KEY);
 
   const { error } = await resend.emails.send({
@@ -47,19 +68,26 @@ async function sendViaResend(options: SendEmailOptions): Promise<void> {
   }
 }
 
-// ─── SMTP Transport (Local / Fallback) ─────────────────────────────
-const transporter = nodemailer.createTransport({
-  host: process.env.SMTP_HOST,
-  port: Number(process.env.SMTP_PORT),
-  secure: process.env.SMTP_SECURE === 'true',
-  auth: {
-    user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASS,
-  },
-});
+// ─── SMTP Transport (Local / Fallback — Lazy Init) ─────────────────
+let _transporter: Transporter | null = null;
 
-async function sendViaSMTP(options: SendEmailOptions): Promise<void> {
-  await transporter.sendMail({
+function getTransporter(): Transporter {
+  if (!_transporter) {
+    _transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT),
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+  }
+  return _transporter;
+}
+
+async function sendViaSMTP(options: SendEmailOptions & { from: string }): Promise<void> {
+  await getTransporter().sendMail({
     from: options.from,
     to: options.to,
     subject: options.subject,
@@ -73,7 +101,7 @@ async function sendViaSMTP(options: SendEmailOptions): Promise<void> {
 }
 
 // Temporary export for compatibility during migration
-export { transporter };
+export { getTransporter as transporter };
 
 /**
  * Returns the environment-specific subject prefix.


### PR DESCRIPTION
## 🐛 Corrections de bugs : Envoi d'emails et UI du formulaire

### 🎯 Objectif
Cette PR résout deux problèmes majeurs :
1. **API / Backend** : L'erreur serveur qui bloquait l'envoi des emails en production.
2. **Interface Utilisateur** : Le problème de défilement (scroll) bloqué sur mobile dans la fenêtre modale de contact.

### 🛠️ Modifications apportées

#### 1. Correction de l'envoi d'emails (Production)
- **Adresse d'expédition canonique** : Introduction de `EMAIL_FROM` comme variable principale pour l'adresse d'expédition, avec un fallback sur `SMTP_FROM` pour maintenir la compatibilité locale.
- **Auto-résolution** : La propriété `from` est devenue optionnelle dans `SendEmailOptions` ; `sendEmail` la résout désormais automatiquement.
- **Nettoyage du code** : Suppression de `process.env.SMTP_FROM` utilisé en dur dans l'action de contact, l'action de message et la route de mot de passe oublié (qui générait un `undefined` sur Vercel et faisait crasher Resend).
- **Optimisation du Transporter** : Implémentation du *lazy-init* sur le transporter SMTP `nodemailer` pour éviter une instanciation inutile en production.
- **Documentation** : Mise à jour de `.env.example`.

#### 2. Amélioration UI (Scroll Mobile)
- **Modale de contact** : Ajout des classes `max-h-dvh` et `overflow-y-auto` sur le conteneur interne pour permettre le défilement vertical si le contenu dépasse la hauteur de l'écran.
- **Ajustement des marges** : Réduction du padding sur les petits écrans (`p-6`) pour optimiser l'espace d'affichage.
- **Linting** : Correction de la syntaxe Tailwind v4 (`z-[9999]` remplacé par `z-9999`).
