### PR TITLE
fix(auth): break infinite redirect loop on session invalidation

### DIFF
--- a/src/app/admin/about/page.tsx
+++ b/src/app/admin/about/page.tsx
@@ -9,7 +9,7 @@ import { UserCircle } from 'lucide-react';
 export default async function AdminAboutPage() {
   const { unauthorized } = await requireAdmin();
   if (unauthorized) {
-    redirect('/admin-login');
+    redirect('/admin-login?error=SessionExpired');
   }
 
   // Next.js cache bypass if necessary or let standard caching operate

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -6,7 +6,7 @@ import { getUmamiStatsAction } from '@/actions/analytics.action';
 export default async function AdminAnalyticsPage() {
   const { unauthorized } = await requireAdmin();
   if (unauthorized) {
-    redirect('/admin-login');
+    redirect('/admin-login?error=SessionExpired');
   }
 
   // Pre-fetch '7d' data on the server

--- a/src/app/admin/cv/page.tsx
+++ b/src/app/admin/cv/page.tsx
@@ -6,7 +6,7 @@ import CvClient from './CvClient';
 export default async function AdminCVPage() {
   const { unauthorized } = await requireAdmin();
   if (unauthorized) {
-    redirect('/admin-login');
+    redirect('/admin-login?error=SessionExpired');
   }
 
   const cv = await prisma.cv.findFirst({

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -7,7 +7,7 @@ export default async function DashboardPage() {
   // 1. Admin authorization (checks session email against Admin table)
   const { unauthorized } = await requireAdmin();
   if (unauthorized) {
-    redirect('/admin-login');
+    redirect('/admin-login?error=SessionExpired');
   }
 
   // 2. Parallel database queries

--- a/src/app/admin/messages/page.tsx
+++ b/src/app/admin/messages/page.tsx
@@ -6,7 +6,7 @@ import MessagesClient from './MessagesClient';
 export default async function MessagesPage() {
   const { unauthorized } = await requireAdmin();
   if (unauthorized) {
-    redirect('/admin-login');
+    redirect('/admin-login?error=SessionExpired');
   }
 
   // Fetch all contacts with nested messages and replies

--- a/src/app/admin/projects/page.tsx
+++ b/src/app/admin/projects/page.tsx
@@ -6,7 +6,7 @@ import ProjectsClient from './ProjectsClient';
 export default async function AdminProjectsPage() {
   const { unauthorized } = await requireAdmin();
   if (unauthorized) {
-    redirect('/admin-login');
+    redirect('/admin-login?error=SessionExpired');
   }
 
   // Fetch all projects, their nested skills, and sorted images

--- a/src/app/admin/security/page.tsx
+++ b/src/app/admin/security/page.tsx
@@ -6,7 +6,7 @@ import { redirect } from 'next/navigation';
 export default async function SecuritySettingsPage() {
   const { session, unauthorized } = await requireAdmin();
   if (unauthorized || !session?.user?.email) {
-    redirect('/admin-login');
+    redirect('/admin-login?error=SessionExpired');
   }
 
   // @react-best-practices: Fetch data on the server and pass minimal props to client

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -22,7 +22,11 @@ export const authConfig = {
       }
 
       if (isLoginPath) {
-        if (isLoggedIn) return Response.redirect(new URL('/admin/dashboard', nextUrl));
+        // Break infinite loop if the server component rejected the session
+        const hasError = nextUrl.searchParams.has('error');
+        if (isLoggedIn && !hasError) {
+          return Response.redirect(new URL('/admin/dashboard', nextUrl));
+        }
         return true;
       }
 


### PR DESCRIPTION
## 🔒 Renforcement Sécurité & Fix Redirect Loop

### 🎯 Objectif
Cette PR comble une faille de maintien de session (les anciens tokens JWT restaient valides après un changement de mot de passe) et corrige une boucle de redirection infinie générée par cette invalidation.

### 🛠️ Modifications
1. **Invalidation Stateful des JWT** (`src/lib/auth.ts`) :
   - Ajout d'une vérification en base de données lors du callback `jwt` de NextAuth.
   - Si la date `passwordUpdatedAt` de l'admin est strictement supérieure à la date de création du token (`iat`), le token est immédiatement rejeté (`null`) et l'utilisateur est déconnecté de force.
2. **Correction Boucle Infinie** (`src/lib/auth.config.ts` & pages admin) :
   - Lorsqu'une session est rejetée, le serveur redirige désormais vers `/admin-login?error=SessionExpired`.
   - Le middleware autorise cette requête spécifique, évitant de rediriger aveuglément vers `/admin/dashboard` sur la seule base de la présence d'un "vieux" cookie JWT.
