### PR TITLE
fix: resolve invisible projects section on mobile and increase card s…

### DIFF
--- a/src/app/sections/MesProjets.tsx
+++ b/src/app/sections/MesProjets.tsx
@@ -88,11 +88,11 @@ export default function MesProjets({ projects }: MesProjetsProps) {
         </m.div>
 
         <m.div
-          className="grid md:grid-cols-3 gap-6"
+          className="grid md:grid-cols-3 gap-10"
           variants={containerVariants}
           initial="hidden"
           whileInView="visible"
-          viewport={{ once: false, amount: 0.5 }}
+          viewport={{ once: false, amount: 0.15 }}
         >
           {projects.map((project: Project, index: number) => (
             <m.div key={project.id} variants={cardVariants}>


### PR DESCRIPTION
## Problème
La section projets était invisible sur mobile à cause du seuil d'animation Framer Motion trop élevé (50% du conteneur devait être visible, impossible sur une colonne mobile).

## Corrections
- Seuil `whileInView` abaissé de 0.5 → 0.15
- Espacement des cartes augmenté (gap-6 → gap-10)
