### PR TITLE
Fix mobile projects section visibility and improve card spacing

### DIFF
--- a/src/app/sections/MesProjets.tsx
+++ b/src/app/sections/MesProjets.tsx
@@ -88,11 +88,11 @@ export default function MesProjets({ projects }: MesProjetsProps) {
         </m.div>
 
         <m.div
-          className="grid md:grid-cols-3 gap-6"
+          className="grid md:grid-cols-3 gap-10"
           variants={containerVariants}
           initial="hidden"
           whileInView="visible"
-          viewport={{ once: false, amount: 0.5 }}
+          viewport={{ once: false, amount: 0.15 }}
         >
           {projects.map((project: Project, index: number) => (
             <m.div key={project.id} variants={cardVariants}>


### PR DESCRIPTION
## Mise en production

Fix de la section projets invisible sur mobile et amélioration de l'espacement des cartes.

- Correction du seuil d'animation Framer Motion (0.5 → 0.15)
- Augmentation du gap entre les cartes (gap-6 → gap-10)
