### PR TITLE
Move JSON-LD to head for improved SSR visibility

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -117,13 +117,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               "try{if(localStorage.theme==='light'){document.documentElement.classList.remove('dark')}else{document.documentElement.classList.add('dark')}}catch(_){}",
           }}
         />
-      </head>
-      <body className="bg-background text-foreground transition-colors duration-300">
-        <Script
-          id="json-ld"
+        <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
+      </head>
+      <body className="bg-background text-foreground transition-colors duration-300">
         <RouteScrollReset>
           <FramerProvider>
             <AppSessionProvider>


### PR DESCRIPTION
## 🔍 Correction SEO : JSON-LD rendu côté serveur

### Problème

Le JSON-LD (données structurées Schema.org) était injecté via le composant `<Script>` de Next.js dans le `<body>`. Par défaut, ce composant utilise la stratégie `afterInteractive`, ce qui signifie que le script n'est pas présent dans le HTML initial généré côté serveur (SSR). Les crawlers (Google, Bing…) ne voyaient donc pas les données structurées lors de l'indexation.

### Solution

- Déplacement du JSON-LD du `<body>` vers le `<head>`
- Remplacement du composant Next.js `<Script>` par une balise HTML native `<script type="application/ld+json">` avec `dangerouslySetInnerHTML`
- Le JSON-LD est désormais inclus dans le HTML initial envoyé par le serveur, garantissant sa visibilité par les moteurs de recherche

### Fichiers modifiés

- `src/app/layout.tsx`

### Validation

- ✅ `npm run validate` (typecheck + lint + 59 tests)