### PR TITLE
Remove 'Portfolio' prefix from site name for SEO compliance

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,13 +51,13 @@ export const metadata: Metadata = {
       'max-snippet': -1,
     },
   },
-  applicationName: 'Portfolio - Hëdi OKBA',
+  applicationName: 'Hëdi OKBA',
   openGraph: {
     title: 'Hëdi OKBA | Développeur Full-Stack',
     description:
       "Développeur passionné par la création d'expériences web modernes, performantes et élégantes.",
     url: APP_URL,
-    siteName: 'Portfolio - Hëdi OKBA',
+    siteName: 'Hëdi OKBA',
     locale: 'fr_FR',
     type: 'website',
     images: [
@@ -96,8 +96,7 @@ const jsonLd = [
   {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
-    name: 'Portfolio - Hëdi OKBA',
-    alternateName: 'Hëdi OKBA',
+    name: 'Hëdi OKBA',
     url: APP_URL,
   },
 ];


### PR DESCRIPTION
## 🔧 Correction du Site Name Google

### Problème

Google rejette le Site Name actuel car il contient le mot descriptif "Portfolio" (`Portfolio - Hëdi OKBA`). En conséquence, Google affiche l'URL brute du domaine à la place du nom du site dans les résultats de recherche.

### Modifications

Fichier modifié : `src/app/layout.tsx`

| Propriété | Avant | Après |
|---|---|---|
| `applicationName` | `Portfolio - Hëdi OKBA` | `Hëdi OKBA` |
| `openGraph.siteName` | `Portfolio - Hëdi OKBA` | `Hëdi OKBA` |
| JSON-LD `WebSite.name` | `Portfolio - Hëdi OKBA` | `Hëdi OKBA` |
| JSON-LD `WebSite.alternateName` | `Hëdi OKBA` | **supprimé** |

### Ce qui n'a pas été modifié

- Le `<title>` des pages (reste descriptif : `Hëdi OKBA | Développeur Full-Stack`)
- Les favicons / icônes
- Les descriptions et autres métadonnées

### Vérification post-déploiement

1. Valider le JSON-LD via le [test des résultats enrichis Google](https://search.google.com/test/rich-results)
2. Demander une réindexation dans la Google Search Console
3. Vérifier que `<meta property="og:site_name" content="Hëdi OKBA" />` est bien présent dans le DOM
