### PR TITLE
Remove 'Portfolio' prefix from site name for SEO compliance

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,13 +51,13 @@ export const metadata: Metadata = {
       'max-snippet': -1,
     },
   },
-  applicationName: 'Portfolio - Hëdi OKBA',
+  applicationName: 'Hëdi OKBA',
   openGraph: {
     title: 'Hëdi OKBA | Développeur Full-Stack',
     description:
       "Développeur passionné par la création d'expériences web modernes, performantes et élégantes.",
     url: APP_URL,
-    siteName: 'Portfolio - Hëdi OKBA',
+    siteName: 'Hëdi OKBA',
     locale: 'fr_FR',
     type: 'website',
     images: [
@@ -96,8 +96,7 @@ const jsonLd = [
   {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
-    name: 'Portfolio - Hëdi OKBA',
-    alternateName: 'Hëdi OKBA',
+    name: 'Hëdi OKBA',
     url: APP_URL,
   },
 ];


### PR DESCRIPTION
## 🚀 Release : Correction du Site Name Google

### Contexte

Google rejette actuellement le Site Name du site car il contient le mot descriptif "Portfolio", et affiche à la place l'URL brute du domaine dans les résultats de recherche.

### Changements inclus

- Suppression du préfixe "Portfolio -" du `applicationName`, `og:site_name` et du JSON-LD `WebSite.name`
- Suppression de la propriété `alternateName` du JSON-LD `WebSite` (devenue redondante)
- Le Site Name est désormais uniformément défini à `Hëdi OKBA` sur tous les signaux

### Impact

- **SEO** : Google devrait accepter le nouveau Site Name et l'afficher correctement dans les SERP
- **Aucune régression visuelle** : les titres de pages, descriptions, favicons et le reste du site ne sont pas impactés

### Actions post-déploiement

1. Vérifier le rendu en production via le [test des résultats enrichis](https://search.google.com/test/rich-results)
2. Demander une réindexation de la page d'accueil dans la [Google Search Console](https://search.google.com/search-console)
